### PR TITLE
Move g8core to zeroos.core0 module (alpha-4 support)

### DIFF
--- a/JumpScale9Lib/clients/g8core/G8CoreFactory.py
+++ b/JumpScale9Lib/clients/g8core/G8CoreFactory.py
@@ -1,12 +1,12 @@
 # from JumpScale9 import j
-import g8core
+from zeroos.core0 import client as g8core
 
 
 class G8CoreFactory():
 
     def __init__(self):
         self.__jslocation__ = "j.clients.g8core"
-        self.__imports__ = g8core
+        self.__imports__ = zeroos
 
     def get(self, host, port=6379, password=''):
         return g8core.Client(host=host, port=port, password=password)

--- a/JumpScale9Lib/clients/g8core/G8CoreFactory.py
+++ b/JumpScale9Lib/clients/g8core/G8CoreFactory.py
@@ -6,7 +6,7 @@ class G8CoreFactory():
 
     def __init__(self):
         self.__jslocation__ = "j.clients.g8core"
-        self.__imports__ = zeroos
+        self.__imports__ = g8core
 
     def get(self, host, port=6379, password=''):
         return g8core.Client(host=host, port=port, password=password)

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     license='Apache',
     packages=['JumpScale9Lib'],
     install_requires=[
+        '0-core-client',
         'Brotli>=0.6.0',
         'Cython>=0.25.2',
         'Jinja2>=2.9.6',
@@ -88,6 +89,9 @@ setup(
         'libvirt-python>=3.3.0',
         'apache_libcloud>=2.0.0',
         'python-etcd>=0.4.5'
+    ],
+    dependency_links=[
+        'git+https://github.com/zero-os/0-core#egg=0-core-client&subdirectory=client/py-client'
     ],
     cmdclass={
         'install': install,


### PR DESCRIPTION
#### Changes proposed in this PR:
Since `1.1.0-alpha-4`, `g8core` is now called `0-core-client` which is used by importing `zeroos.core0`.
This PR change the smallest possible part to import the new version of the client, without changing implementation, this will ensure retro-compatibility.

This means that `j.clients.g8core` still exists but uses `zeroos.core0 client` behind.

### Important
Also note that this PR will use **git** version of 0-core-client. This need to be adjusted during release phase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jumpscale/lib9/9)
<!-- Reviewable:end -->
