### PR TITLE
Remove 0-core-client from deps and use git link only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def _post_install(libname, libpath):
     c = j.core.state.configGet('plugins', defval={})
     c[libname] = libpath
     j.core.state.configSet('plugins', c)
-
+    j.do.execute("pip3 install 'git+https://github.com/zero-os/0-core#egg=0-core-client&subdirectory=client/py-client'")
     j.tools.jsloader.generatePlugins()
 
 
@@ -90,9 +90,6 @@ setup(
         'python-etcd>=0.4.5',
         'zerotier>=1.1.2',
         'packet-python>=1.33'
-    ],
-    dependency_links=[
-        'git+https://github.com/zero-os/0-core#egg=0-core-client&subdirectory=client/py-client'
     ],
     cmdclass={
         'install': install,

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     license='Apache',
     packages=['JumpScale9Lib'],
     install_requires=[
-        '0-core-client',
         'Brotli>=0.6.0',
         'Cython>=0.25.2',
         'Jinja2>=2.9.6',


### PR DESCRIPTION
#### What this PR resolves:
fail of setup on installing 0-core-client library

#### Changes proposed in this PR:

-
-


**Version**: 

**Fixes**: #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jumpscale/lib9/13)
<!-- Reviewable:end -->
