### PR TITLE
add gethistory to openvcloud machine client

### DIFF
--- a/JumpScale9Lib/clients/openvcloud/Client.py
+++ b/JumpScale9Lib/clients/openvcloud/Client.py
@@ -528,6 +528,9 @@ class Machine:
     def delete_snapshot(self, epoch):
         self.client.api.cloudapi.machines.deleteSnapshot(machineId=self.id, epoch=epoch)
 
+    def getHistory(self, size):
+        return self.client.api.cloudapi.machines.getHistory(machineId=self.id, size=size)
+
     def add_disk(self, name, description, size=10, type='D', ssdSize=0):
         disk_id = self.client.api.cloudapi.machines.addDisk(machineId=self.id,
                                                             diskName=name,


### PR DESCRIPTION
#### What this PR resolves:
Adding getHistory to openvcloud API


**Version**: 9.1.0

**Fixes**: #https://github.com/Jumpscale/ays9/issues/83

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jumpscale/lib9/40)
<!-- Reviewable:end -->
