### PR TITLE
OVC Client: set login correct when using jwt

### DIFF
--- a/JumpScale9Lib/clients/openvcloud/Client.py
+++ b/JumpScale9Lib/clients/openvcloud/Client.py
@@ -161,7 +161,7 @@ class Client:
                 jwt = refresh_jwt(jwt, payload)
             self.api._session.headers['Authorization'] = 'bearer {}'.format(
                 jwt)
-            self._login = payload['username']
+            self._login = '{}@{}'.format(payload['username'], payload['iss'])
         else:
             if password:
                 if self._isms1:


### PR DESCRIPTION
When signing in with jwt token make sure we set correct username on
local client

Fixes: #101

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>