### PR TITLE
update signature of ays.get()

### DIFF
--- a/JumpScale9Lib/clients/atyourservice/ays/ClientFactory.py
+++ b/JumpScale9Lib/clients/atyourservice/ays/ClientFactory.py
@@ -7,7 +7,7 @@ class ClientFactory:
     def __init__(self):
         self.__jslocation__ = 'j.clients.ays'
 
-    def get(self, client_id, client_secret, url=DEFAULT_URL, validity=3600):
+    def get(self, url=DEFAULT_URL, client_id=None, client_secret=None, validity=3600):
         """
         Get an AYS client to interact with a local or remote AYS server.
 

--- a/docs/Howto/AYS_client.md
+++ b/docs/Howto/AYS_client.md
@@ -31,7 +31,7 @@ import os
 client_id = os.environ["CLIENT_ID"]
 secret = os.environ["SECRET"]
 url = "http://192.168.196.5:5000"
-cl = j.clients.ays.getWithClientID(clientID=client_id, secret=secret, url=url)
+cl = j.clients.ays.getWithClientID(url=url, clientID=client_id, secret=secret)
 ```
 
 Or in case you saved the client ID and password in a YAML formated configuration file:


### PR DESCRIPTION
#### What this PR resolves:

Previously you had to pass explicitly `client_id=None` and `secret=None` when there is no ItsYou.online integration configured, with this update you can simply execute:
```python
ays = j.clients.ays.get(ays_url)
```

