### PR TITLE
catch exception if trying to add key when no parent

### DIFF
--- a/JumpScale9Lib/clients/itsyouonline/ApiKey.py
+++ b/JumpScale9Lib/clients/itsyouonline/ApiKey.py
@@ -81,6 +81,9 @@ class ApiKeys:
             except Exception as e:
                 logging.exception("Unable to create a new API key for organization %s" % (self._parent.model["globalid"]))
                 return
+        else:
+            logging.exception("Unable to create new API key")
+            return
 
         if resp.ok:
             return self.get(label)


### PR DESCRIPTION
#### What this PR resolves:

Catch the exception when someone is trying to add an API key for an invalid user or organization
