### PR TITLE
Removes html body to be in ApiError message

### DIFF
--- a/JumpScale9Lib/clients/portal/PortalClient.py
+++ b/JumpScale9Lib/clients/portal/PortalClient.py
@@ -16,11 +16,12 @@ JSBASE = j.application.jsbase_get_class()
 class ApiError(Exception, JSBASE):
 
     def __init__(self, response):
+        message = None
         msg = '%s %s' % (response.status_code, response.reason)
         try:
             message = response.json()
         except BaseException:
-            message = response.content
+            pass
         if isinstance(message, (str, bytes)):
             msg += '\n%s' % message
         elif isinstance(message, dict) and 'errormessage' in message:


### PR DESCRIPTION
The error message will not be set anymore with the response body/content (if not JSON) to prevent HTML to be in the error message which can be annoying in logs.

Fixes #187 
Fixes https://github.com/openvcloud/0-templates/issues/62