### PR TITLE
Add methods to refresh jwt

### DIFF
--- a/JumpScale9Lib/clients/itsyouonline/IYOFactory.py
+++ b/JumpScale9Lib/clients/itsyouonline/IYOFactory.py
@@ -3,6 +3,7 @@
 from js9 import j
 from .IYOClient import IYOClient
 import requests
+import jwt
 
 DEFAULT_BASE_URL = "https://itsyou.online/api"
 
@@ -77,3 +78,11 @@ class IYOFactory(JSConfigBaseFactory):
 
         key_labels = [k.label for k in client.api.users.ListAPIKeys(username).data]
         assert 'test' not in key_labels
+
+    def jwt_expire_timestamp(self, token):
+        '''
+        Get expiration date of jwt token
+        '''
+
+        jwt_data = jwt.decode(token, verify=False)
+        return jwt_data['exp']

--- a/JumpScale9Lib/clients/openvcloud/OVCClient.py
+++ b/JumpScale9Lib/clients/openvcloud/OVCClient.py
@@ -54,7 +54,7 @@ class OVCClient(JSConfigBase):
             token = j.clients.itsyouonline.refresh_jwt_token(self.config.data['jwt_'], validity=3600)
             self.config.data_set('jwt_', token)
             self.config.save()
-            self._jwt_expire_timestamp = j.clients.itsyouonline.jwt_expire_timestamp(self.config.data['jwt_'])
+            self._jwt_expire_timestamp = j.clients.itsyouonline.jwt_expire_timestamp(token)
 
     @property
     def api(self):

--- a/JumpScale9Lib/clients/openvcloud/OVCClient.py
+++ b/JumpScale9Lib/clients/openvcloud/OVCClient.py
@@ -52,7 +52,7 @@ class OVCClient(JSConfigBase):
 
         if self._jwt_expire_timestamp and self._jwt_expire_timestamp - 300 < time.time():
             token = j.clients.itsyouonline.refresh_jwt_token( self.config.data['jwt_'], validity=3600)
-            self.config.data['jwt_'] = token
+            self.config.data_set('jwt_', token)
             self.config.save()
 
     @property

--- a/JumpScale9Lib/clients/openvcloud/OVCClient.py
+++ b/JumpScale9Lib/clients/openvcloud/OVCClient.py
@@ -51,9 +51,10 @@ class OVCClient(JSConfigBase):
             self._jwt_expire_timestamp = j.clients.itsyouonline.jwt_expire_timestamp(self.config.data['jwt_'])
 
         if self._jwt_expire_timestamp and self._jwt_expire_timestamp - 300 < time.time():
-            token = j.clients.itsyouonline.refresh_jwt_token( self.config.data['jwt_'], validity=3600)
+            token = j.clients.itsyouonline.refresh_jwt_token(self.config.data['jwt_'], validity=3600)
             self.config.data_set('jwt_', token)
             self.config.save()
+            self._jwt_expire_timestamp = j.clients.itsyouonline.jwt_expire_timestamp(self.config.data['jwt_'])
 
     @property
     def api(self):

--- a/JumpScale9Lib/clients/zero_os/Client.py
+++ b/JumpScale9Lib/clients/zero_os/Client.py
@@ -71,16 +71,14 @@ class Client(BaseClient, JSConfigClientBase):
     def _redis(self):
         password = self.config.data['password_']
         if password and not self._jwt_expire_timestamp:
-            jwt_data = jwt.decode(password, verify=False)
-            self._jwt_expire_timestamp = jwt_data['exp']
+            self._jwt_expire_timestamp = j.clients.itsyouonline.jwt_expire_timestamp(password)
         if self._jwt_expire_timestamp and self._jwt_expire_timestamp - 300 < time.time():
             password = j.clients.itsyouonline.refresh_jwt_token(password, validity=3600)
             self.config.data_set('password_', password)
             self.config.save()
             if self.__redis:
                 self.__redis = None
-            jwt_data = jwt.decode(password, verify=False)
-            self._jwt_expire_timestamp = jwt_data['exp']
+            self._jwt_expire_timestamp = j.clients.itsyouonline.jwt_expire_timestamp(password)
 
         if self.__redis is None:
             timeout = self.config.data['timeout']
@@ -205,6 +203,7 @@ class Client(BaseClient, JSConfigClientBase):
         :param id: job id. Generated if not supplied
         :return: Response object
         """
+
         if not id:
             id = str(uuid.uuid4())
 


### PR DESCRIPTION
#### What this PR resolves:
Refresh expired (or almost expired) jwt token instead of throwing authentication error

#### Changes proposed in this PR:
- added method to get expiry date of jwt `j.clients.itsyouonline.jwt_expire_timestamp()` 
- added method `.jwt_refresh()` to `ovc` client


**Version**: 

**Fixes**: #
